### PR TITLE
ES module do not need "use strict"

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -6,8 +6,6 @@
  * @author otakustay
  */
 
-'use strict';
-
 let clone = target => Object.entries(target).reduce(
     (result, [key, value]) => {
         result[key] = value;


### PR DESCRIPTION
ES module:

> Module code automatically runs in strict mode and there's no way to opt-out of strict mode.
